### PR TITLE
Change pid conf file name

### DIFF
--- a/stunnel/init.sls
+++ b/stunnel/init.sls
@@ -47,7 +47,7 @@ stunnel_package:
       - service: stunnel_service
 
 {% if grains['os_family'] == 'FreeBSD' -%}
-{{ stunnel.conf_dir }}/conf.d/pid.conf:
+{{ stunnel.conf_dir }}/conf.d/00-pid.conf:
   file.absent: []
 {% endif -%}
 


### PR DESCRIPTION
The pid conf file has been changed to `00-pid.conf` in FreeBSD